### PR TITLE
Bottom Slice Flickering

### DIFF
--- a/src/tour.js
+++ b/src/tour.js
@@ -280,7 +280,8 @@ var Tour = new Class({
         '3': {
           'height': window.getScrollSize().y - (elCoords.top + elCoords.height),
           'width': windowWidth,
-          'top': elCoords.top + elCoords.height
+          'top': elCoords.top,
+          'margin-top': elCoords.height
         }
       });
     }


### PR DESCRIPTION
I noticed a slight flickering on the bottom slice during animation. After a little search I noticed that all the other slices animate to 'elCoords.top' and 'elCoords.height' distinct values, but the bottom animates to their sum, which probably, due to rounding, produces slight different values than the other transitions.
So, I thought of this little change to use the same transitions amongst all the slices.
